### PR TITLE
Interface change.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 echo "Setting up revtrvp and starting the traffic listener."
 
 # Setup a cron schedule
-echo "*/30 * * * * bash /traffic_monitoring/traffic_listener_cron.sh >> /var/log/cron.log 2>&1
+echo "* * * * * bash /traffic_monitoring/traffic_listener_cron.sh >> /var/log/cron.log 2>&1
 # Don't remove the empty line at the end of this file. It is required to run the cron job" > /traffic_monitoring/traffic_crontab
 
 crontab /traffic_monitoring/traffic_crontab

--- a/util/util.go
+++ b/util/util.go
@@ -229,16 +229,15 @@ func MicroToNanoSec(usec int64) int64 {
 	return usec * 1000
 }
 
-// GetBindAddr gets the IP of the eth0 like address
+// GetBindAddr gets the IP of the eth0 like address 
+// (!!MLab specific!!: use net1 because eth0 is private)
 func GetBindAddr() (string, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return "", err
 	}
 	for _, iface := range ifaces {
-		if strings.Contains(iface.Name, "em1") ||
-			strings.Contains(iface.Name, "eth0") ||
-            strings.Contains(iface.Name, "ens3") &&
+		if strings.Contains(iface.Name, "net1") &&
 				uint(iface.Flags)&uint(net.FlagUp) > 0 {
 			addrs, err := iface.Addrs()
 			if err != nil {
@@ -252,5 +251,5 @@ func GetBindAddr() (string, error) {
 			return ip.String(), nil
 		}
 	}
-	return "", fmt.Errorf("Didn't find eth0 interface")
+	return "", fmt.Errorf("Didn't find net1 interface")
 }


### PR DESCRIPTION
- Code searches for eth0. A previous meeting showed that MLab uses eth0 with a private IP. net1 is the correct interface to use for the public IP.
- Changed cronjob to get one packet capture per minute instead of per 30 minutes. 