### PR TITLE
Standalone test of icmp.go

### DIFF
--- a/icmp_main.go
+++ b/icmp_main.go
@@ -86,6 +86,7 @@ func getProbe(conn *ipv4.RawConn) (error) {
 	fname := "/var/spool/revtr/traffic/spooflistener_" + now + ".log"
 	logf, errf := os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
+	defer logf.Close()
 	if errf != nil {
 		log.Error(errf)
 	}
@@ -223,7 +224,19 @@ func reconnect(addr string) (*ipv4.RawConn, error) {
 
 func main(){
 	addr, _ := GetBindAddr()
-	fmt.Println("addr is: " + addr)
+	now := time.Now().Format("2006_01_02_15_04")
+	fname := "/var/spool/revtr/traffic/addr_config" + now
+	logf, errf := os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+
+	defer logf.Close()
+
+	if errf != nil {
+		log.Error(errf)
+	}
+
+	if _, errf := logf.WriteString("addr is: " + addr); errf != nil {
+		log.Error(errf)
+	}
 	c, err := reconnect(addr)
 	if err != nil {
 		fmt.Println("error")

--- a/icmp_main.go
+++ b/icmp_main.go
@@ -192,7 +192,7 @@ func GetBindAddr() (string, error) {
 		return "", err
 	}
 	for _, iface := range ifaces {
-		if strings.Contains(iface.Name, "eth0") &&
+		if strings.Contains(iface.Name, "net1") &&
 			uint(iface.Flags)&uint(net.FlagUp) > 0 {
 			addrs, err := iface.Addrs()
 			if err != nil {

--- a/icmp_main.go
+++ b/icmp_main.go
@@ -78,8 +78,13 @@ func makeTimestamp(ts opt.TimeStampOption) (dm.TimeStamp, error) {
 func getProbe(conn *ipv4.RawConn) (error) {
 	// 1500 should be good because we're sending small packets and its the standard MTU
 
-	// 1500 should be good because we're sending small packets and its the standard MTU
-
+	pBuf := make([]byte, 1500)
+	probe := &dm.Probe{}
+	// Try and get a packet
+	header, pload, _, err := conn.ReadFrom(pBuf)
+	if err != nil {
+		return ErrorReadError
+	}
 	now := time.Now().Format("2006_01_02_15_04")
 
 	// Directory structure is MLab specific, where MLab's Pusher service sends everything to Google Cloud Storage.
@@ -91,16 +96,6 @@ func getProbe(conn *ipv4.RawConn) (error) {
 		log.Error(errf)
 	}
 
-	if _, errf := logf.WriteString("Inside getProbe, trying to get a packet\n"); errf != nil {
-		log.Error(errf)
-	}
-	pBuf := make([]byte, 1500)
-	probe := &dm.Probe{}
-	// Try and get a packet
-	header, pload, _, err := conn.ReadFrom(pBuf)
-	if err != nil {
-		return ErrorReadError
-	}
 	// Parse the payload for ICMP stuff
 	if _, errf := logf.WriteString("Got packet, parsing payload for ICMP stuff\n"); errf != nil {
 		log.Error(errf)

--- a/icmp_main.go
+++ b/icmp_main.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"fmt"
+	"github.com/NEU-SNS/revtrvp/log"
+	"github.com/NEU-SNS/revtrvp/plvp"
+	"github.com/NEU-SNS/revtrvp/util"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	dm "github.com/NEU-SNS/revtrvp/datamodel"
+	opt "github.com/rhansen2/ipv4optparser"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+)
+
+const (
+	// ID is the ICMDPID magic number
+	ID = 0xf0f1
+	// SEQ is the ICMP seq number magic number
+	SEQ = 0xf2f3
+)
+
+var (
+	dummy           ipv4.ICMPType
+	icmpProtocolNum = dummy.Protocol()
+)
+
+
+var (
+	// ErrorNotICMPEcho is returned when the probe is not of the right type
+	ErrorNotICMPEcho = fmt.Errorf("Received Non ICMP Probe")
+	// ErrorNonSpoofedProbe is returned when the probe is not spoofed
+	ErrorNonSpoofedProbe = fmt.Errorf("Received ICMP Probe that was not spoofed")
+	// ErrorSpoofedProbeNoID is returned when the probe has no ID
+	ErrorSpoofedProbeNoID = fmt.Errorf("Received a spoofed probe with no id")
+	// ErrorNoSpooferIP is returned when there is no spoofer ip in the packet
+	ErrorNoSpooferIP = fmt.Errorf("No spoofer IP found in packet")
+	// ErrorFailedToParseOptions is returned when there was an error parsing options
+	ErrorFailedToParseOptions = fmt.Errorf("Failed to parse IPv4 options")
+	// ErrorFailedToConvertOption is returned when there is an issue converting an option
+	ErrorFailedToConvertOption = fmt.Errorf("Failed to convert IPv4 option")
+	// ErrorSpooferIP is returned when the spoofer ip is invalid
+	ErrorSpooferIP = fmt.Errorf("Failed to convert spoofer ip")
+	// ErrorReadError is returned when there is an error reading from the icmp monitoring conn
+	ErrorReadError = fmt.Errorf("Failed to read from conn")
+)
+
+func makeID(a, b, c, d byte) uint32 {
+	var id uint32
+	id |= uint32(a) << 24
+	id |= uint32(b) << 16
+	id |= uint32(c) << 8
+	id |= uint32(d)
+	return id
+}
+
+func makeRecordRoute(rr opt.RecordRouteOption) (dm.RecordRoute, error) {
+	rec := dm.RecordRoute{}
+	for _, r := range rr.Routes {
+		rec.Hops = append(rec.Hops, uint32(r))
+	}
+	return rec, nil
+}
+
+func makeTimestamp(ts opt.TimeStampOption) (dm.TimeStamp, error) {
+	time := dm.TimeStamp{}
+	time.Type = dm.TSType(ts.Flags)
+	for _, st := range ts.Stamps {
+		nst := dm.Stamp{Time: uint32(st.Time), Ip: uint32(st.Addr)}
+		time.Stamps = append(time.Stamps, &nst)
+	}
+	return time, nil
+}
+
+func getProbe(conn *ipv4.RawConn) (error) {
+	// 1500 should be good because we're sending small packets and its the standard MTU
+
+	fmt.Println("Inside getProbe, trying to get a packet\n")
+
+	pBuf := make([]byte, 1500)
+	probe := &dm.Probe{}
+	// Try and get a packet
+	header, pload, _, err := conn.ReadFrom(pBuf)
+	if err != nil {
+		return ErrorReadError
+	}
+	// Parse the payload for ICMP stuff
+	fmt.Println("Got packet, parsing payload for ICMP stuff\n")
+	mess, err := icmp.ParseMessage(icmpProtocolNum, pload)
+	if err != nil {
+		return err
+	}
+	if echo, ok := mess.Body.(*icmp.Echo); ok {
+		fmt.Println("Checking if ID (" + strconv.Itoa(echo.ID) +  ") and SEQ (" + strconv.Itoa(echo.Seq) + ") are correct values.\n")
+
+		if echo.ID != ID || echo.Seq != SEQ {
+			return ErrorNonSpoofedProbe
+		}
+
+		if len(echo.Data) < 8 {
+			return ErrorSpoofedProbeNoID
+		}
+		// GetIP of spoofer out of packet
+		ip := net.IPv4(echo.Data[0],
+			echo.Data[1],
+			echo.Data[2],
+			echo.Data[3])
+		if ip == nil {
+			return ErrorNoSpooferIP
+		}
+		fmt.Println("get IP of spoofer out of packet: " + ip.String() + "\n" )
+
+		// Get the Id out of the data
+		id := makeID(echo.Data[4], echo.Data[5], echo.Data[6], echo.Data[7])
+		probe.ProbeId = id
+		probe.SpooferIp, err = util.IPtoInt32(ip)
+		if err != nil {
+			return ErrorSpooferIP
+		}
+		probe.Dst, err = util.IPtoInt32(header.Dst)
+		probe.Src, err = util.IPtoInt32(header.Src)
+		fmt.Println("Src: "  + header.Src.String() + " and Dst: " + header.Dst.String() + "\n")
+
+		// Parse the options
+		options, err := opt.Parse(header.Options)
+		if err != nil {
+			return ErrorFailedToParseOptions
+		}
+		probe.SeqNum = uint32(echo.Seq)
+		probe.Id = uint32(echo.ID)
+		for _, option := range options {
+			switch option.Type {
+			case opt.RecordRoute:
+				fmt.Println("Case RecordRoute\n")
+
+				rr, err := option.ToRecordRoute()
+				if err != nil {
+					return ErrorFailedToConvertOption
+				}
+				rec, err := makeRecordRoute(rr)
+				if err != nil {
+					return ErrorFailedToConvertOption
+				}
+				probe.RR = &rec
+			case opt.InternetTimestamp:
+				fmt.Println("Case Timestamp\n")
+
+				ts, err := option.ToTimeStamp()
+				if err != nil {
+					return ErrorFailedToConvertOption
+				}
+				nts, err := makeTimestamp(ts)
+				if err != nil {
+					return ErrorFailedToConvertOption
+				}
+				probe.Ts = &nts
+			}
+		}
+	}
+	return ErrorNotICMPEcho
+}
+
+// GetBindAddr gets the IP of the eth0 like address
+// (!!MLab specific!!: use net1 because eth0 is private)
+func GetBindAddr() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	for _, iface := range ifaces {
+		if strings.Contains(iface.Name, "eth0") &&
+			uint(iface.Flags)&uint(net.FlagUp) > 0 {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				return "", err
+			}
+			addr := addrs[0]
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				return "", err
+			}
+			return ip.String(), nil
+		}
+	}
+	return "", fmt.Errorf("Didn't find net1 interface")
+}
+
+func reconnect(addr string) (*ipv4.RawConn, error) {
+	pc, err := net.ListenPacket(fmt.Sprintf("ip4:%d", icmpProtocolNum), addr)
+	if err != nil {
+		return nil, err
+	}
+	return ipv4.NewRawConn(pc)
+}
+
+func main(){
+	addr, _ := GetBindAddr()
+	fmt.Println("addr is: " + addr)
+	c, err := reconnect(addr)
+	if err != nil {
+		fmt.Println("error")
+		return
+	}
+	for {
+		fmt.Println("Listening for a new probe.")
+		getProbe(c)
+	}
+}

--- a/icmp_main.go
+++ b/icmp_main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"fmt"
 	"github.com/NEU-SNS/revtrvp/log"
-	"github.com/NEU-SNS/revtrvp/plvp"
 	"github.com/NEU-SNS/revtrvp/util"
 	"net"
-	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	dm "github.com/NEU-SNS/revtrvp/datamodel"
 	opt "github.com/rhansen2/ipv4optparser"
@@ -199,14 +196,14 @@ func reconnect(addr string) (*ipv4.RawConn, error) {
 
 func main(){
 	addr, _ := GetBindAddr()
-	fmt.Println("addr is: " + addr)
+	log.Debug("addr is: " + addr)
 	c, err := reconnect(addr)
 	if err != nil {
 		fmt.Println("error")
 		return
 	}
 	for {
-		fmt.Println("Listening for a new probe.")
+		log.Debug("Listening for a new probe.")
 		getProbe(c)
 	}
 }

--- a/icmp_main.go
+++ b/icmp_main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/NEU-SNS/revtrvp/log"
 	"github.com/NEU-SNS/revtrvp/util"
 	"net"
 	"strconv"
@@ -196,14 +195,14 @@ func reconnect(addr string) (*ipv4.RawConn, error) {
 
 func main(){
 	addr, _ := GetBindAddr()
-	log.Debug("addr is: " + addr)
+	fmt.Println("addr is: " + addr)
 	c, err := reconnect(addr)
 	if err != nil {
 		fmt.Println("error")
 		return
 	}
 	for {
-		log.Debug("Listening for a new probe.")
+		fmt.Println("Listening for a new probe.")
 		getProbe(c)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func init() {
 	}
 }
 
-func main() {
+func main_x() {
 	go sigHandle()
 	err := config.Parse(flag.CommandLine, &conf)
 	if err != nil {

--- a/plvp/icmp.go
+++ b/plvp/icmp.go
@@ -123,6 +123,13 @@ func makeTimestamp(ts opt.TimeStampOption) (dm.TimeStamp, error) {
 func getProbe(conn *ipv4.RawConn) (*dm.Probe, error) {
 	// 1500 should be good because we're sending small packets and its the standard MTU
 
+	pBuf := make([]byte, 1500)
+	probe := &dm.Probe{}
+	// Try and get a packet
+	header, pload, _, err := conn.ReadFrom(pBuf)
+	if err != nil {
+		return nil, ErrorReadError
+	}
 	now := time.Now().Format("2006_01_02_15_04")
 
 	// Directory structure is MLab specific, where MLab's Pusher service sends everything to Google Cloud Storage.
@@ -134,17 +141,6 @@ func getProbe(conn *ipv4.RawConn) (*dm.Probe, error) {
 	}
 
 	defer logf.Close()
-
-	if _, errf := logf.WriteString("Inside getProbe, trying to get a packet\n"); errf != nil {
-		log.Error(errf)
-	}
-	pBuf := make([]byte, 1500)
-	probe := &dm.Probe{}
-	// Try and get a packet
-	header, pload, _, err := conn.ReadFrom(pBuf)
-	if err != nil {
-		return nil, ErrorReadError
-	}
 	// Parse the payload for ICMP stuff
 	if _, errf := logf.WriteString("Got packet, parsing payload for ICMP stuff\n"); errf != nil {
 		log.Error(errf)

--- a/plvp/plvantagepoint.go
+++ b/plvp/plvantagepoint.go
@@ -51,6 +51,7 @@ import (
 	"net/http"
 )
 
+
 var (
 	procCollector = prometheus.NewProcessCollectorPIDFn(func() (int, error) {
 		return os.Getpid(), nil


### PR DESCRIPTION
We've narrowed the traffic capture problem to a single method in the code. This new version tries only to run that part, independent of the rest of revtr. icmp_main.go has that method, alongside some helper functions needed to run the method.