### PR TITLE
nil pointer dereferencing fix

### DIFF
--- a/plvp/icmp.go
+++ b/plvp/icmp.go
@@ -145,7 +145,7 @@ func getProbe(conn *ipv4.RawConn) (*dm.Probe, error) {
 	if _, errf := logf.WriteString("Got packet, parsing payload for ICMP stuff\n"); errf != nil {
 		log.Error(errf)
 	}
-	fmt.Printf("Got packet, parsing payload for ICMP stuff")
+	fmt.Printf("Got packet, parsing payload for ICMP stuff\n")
 
 	mess, err := icmp.ParseMessage(icmpProtocolNum, pload)
 	if err != nil {

--- a/plvp/icmp.go
+++ b/plvp/icmp.go
@@ -266,9 +266,13 @@ func (sm *SpoofPingMonitor) poll(addr string, probes chan<- dm.Probe, ec chan er
 			lgg += srcs
 			lgg += " dst= "
 			lgg += dsts
-			for _, hop := range pr.RR.Hops {
-				hopstr, _ := util.Int32ToIPString(hop)
-				lgg += hopstr + " "
+			if pr.GetRR() != nil  {
+				if pr.GetRR().GetHops() != nil {
+					for _, hop := range pr.GetRR().Hops {
+						hopstr, _ := util.Int32ToIPString(hop)
+						lgg += hopstr + " "
+					}
+				}
 			}
 
 			log.Debug(lgg)

--- a/plvp/icmp.go
+++ b/plvp/icmp.go
@@ -260,6 +260,7 @@ func (sm *SpoofPingMonitor) poll(addr string, probes chan<- dm.Probe, ec chan er
 				}
 				continue
 			}
+
 			lgg := "getProbe returned: src= "
 			srcs, _ := util.Int32ToIPString(pr.Src)
 			dsts, _ := util.Int32ToIPString(pr.Dst)
@@ -268,14 +269,12 @@ func (sm *SpoofPingMonitor) poll(addr string, probes chan<- dm.Probe, ec chan er
 			lgg += dsts
 			if pr.GetRR() != nil  {
 				if pr.GetRR().GetHops() != nil {
-					for _, hop := range pr.GetRR().Hops {
+					for _, hop := range pr.GetRR().GetHops() {
 						hopstr, _ := util.Int32ToIPString(hop)
 						lgg += hopstr + " "
 					}
 				}
 			}
-
-			log.Debug(lgg)
 			fmt.Println(lgg)
 
 			probes <- *pr

--- a/plvp/plvantagepoint.go
+++ b/plvp/plvantagepoint.go
@@ -125,7 +125,9 @@ func (cs *PLControllerSender) Send(ps []*dm.Probe) error {
 	client := plc.NewPLControllerClient(cs.conn)
 	contx, cancel := ctx.WithTimeout(ctx.Background(), time.Second*2)
 	defer cancel()
+	fmt.Println("calling client.AcceptProbes to server")
 	_, err := client.AcceptProbes(contx, &dm.SpoofedProbes{Probes: ps})
+	fmt.Println(err)
 	return err
 }
 

--- a/plvp/plvantagepoint.go
+++ b/plvp/plvantagepoint.go
@@ -92,7 +92,6 @@ type PLControllerSender struct {
 
 func (cs *PLControllerSender) Send(ps []*dm.Probe) error {
 
-	fmt.Printf("Sending back to plcontroller")
 	for _, p := range ps {
 		srcs, _ := util.Int32ToIPString(p.Src)
 		dsts, _ := util.Int32ToIPString(p.Dst)
@@ -103,8 +102,8 @@ func (cs *PLControllerSender) Send(ps []*dm.Probe) error {
 			hopstr, _ := util.Int32ToIPString(hop)
 			lgg += hopstr + " "
 		}
-		fmt.Println(lgg)
-		log.Debug(lgg)
+		fmt.Println("Sending back to controller: " + lgg)
+
 	}
 	if cs.conn == nil {
 		_, srvs, err := net.LookupSRV("plcontroller", "tcp", "revtr.ccs.neu.edu")

--- a/plvp/plvantagepoint.go
+++ b/plvp/plvantagepoint.go
@@ -121,11 +121,12 @@ func (cs *PLControllerSender) Send(ps []*dm.Probe) error {
 		}
 		cs.conn = cc
 	}
-
+	fmt.Println("Establishing PLController conn...")
 	client := plc.NewPLControllerClient(cs.conn)
+	fmt.Println("PLController conn established.")
 	contx, cancel := ctx.WithTimeout(ctx.Background(), time.Second*2)
 	defer cancel()
-	fmt.Println("calling client.AcceptProbes to server")
+	fmt.Println("calling AcceptProbes to server")
 	_, err := client.AcceptProbes(contx, &dm.SpoofedProbes{Probes: ps})
 	fmt.Println(err)
 	return err


### PR DESCRIPTION
Non-RecordRoute probes go through the same channel, so now using a getter that checks for the existence of RR array. Should provide a solution to the crashes mentioned on Slack revtr channel on July 21st.